### PR TITLE
fix/extract-shipping-info

### DIFF
--- a/src/v1/src/ebay/extract.py
+++ b/src/v1/src/ebay/extract.py
@@ -59,6 +59,7 @@ def extract_shipping_details(order: dict, shipping_details: dict):
 
     except Exception as error:
         print(traceback.format_exc())
+        return {}
 
 
 def extract_taxes(transaction: dict):

--- a/src/v1/src/ebay/handler.py
+++ b/src/v1/src/ebay/handler.py
@@ -474,7 +474,7 @@ async def handle_new_order(
         buyer_additional_fees = (
             0.0
             if is_cancelled
-            else round(total_sale_price - sale_price - shipping["fees"] - tax_amount, 2)
+            else round(total_sale_price - sale_price - shipping.get("fees", 0) - tax_amount, 2)
         )
 
         image = listing_data.get("image")


### PR DESCRIPTION
- in extract_shipping_info return {} in catch block
- where the function is called, use .get instead of direct access with []